### PR TITLE
Small cleanups in CreateTransaction RPC

### DIFF
--- a/grpc/adapters.go
+++ b/grpc/adapters.go
@@ -56,7 +56,7 @@ func BitcoinAddressEncoding(encoding pb.AddressEncoding) (bitcoin.AddressEncodin
 
 // Tx is an adapter function to build a *bitcoin.Tx object from a gRPC message.
 // It also converts raw gRPC values to a format that is acceptable to btcd.
-func Tx(txProto *pb.UnsignedTransactionRequest) (*bitcoin.Tx, error) {
+func Tx(txProto *pb.CreateTransactionRequest) (*bitcoin.Tx, error) {
 	var inputs []bitcoin.Input
 	for _, inputProto := range txProto.Inputs {
 		inputs = append(inputs, bitcoin.Input{

--- a/pb/bitcoin/service.proto
+++ b/pb/bitcoin/service.proto
@@ -31,11 +31,9 @@ service CoinService {
   // HD version bytes during encoding.
   rpc EncodeAddress(EncodeAddressRequest) returns (EncodeAddressResponse) {}
 
-
-
   // Create a Transaction
   // the created transaction is returned to be signed
-  rpc CreateTransaction(UnsignedTransactionRequest) returns (UnsignedTransactionResponse) {}
+  rpc CreateTransaction(CreateTransactionRequest) returns (CreateTransactionResponse) {}
 }
 
 // BitcoinNetwork enumerates the list of all supported Bitcoin networks. It
@@ -156,9 +154,9 @@ message EncodeAddressResponse {
 }
 
 
-// UnsignedTransactionRequest defines the input request passed to CreateTransaction
-// RPC method.
-message UnsignedTransactionRequest {
+// CreateTransactionRequest defines the input request passed to the
+// CreateTransaction RPC method.
+message CreateTransactionRequest {
   // Lock time during which the transaction cannot be broadcasted
   uint32 lock_time = 1;
   // Inputs : UTXOs used to send coins
@@ -169,11 +167,22 @@ message UnsignedTransactionRequest {
   BitcoinNetwork network = 4;
 }
 
-// UnsignedTransactionResponse defines the output request passed to CreateTransaction
-// RCP method
-message UnsignedTransactionResponse {
-  // This contains the unsigned transaction in HEX format.
+// CreateTransactionResponse defines the output response passed to the
+// CreateTransaction RCP method.
+message CreateTransactionResponse {
+  // hex contains the unsigned transaction serialized according to bitcoin
+  // encoding.
   string hex = 1;
+
+  // hash contains the transaction hash, which is computed by doing a
+  // double-SHA256 on the encoded transaction.
+  string hash = 2;
+
+  // witness_hash contains hash of the transaction, that is encoded according to
+  // the BIP144 Witness serialization rules.
+  //
+  // Same as hash if no witness is present.
+  string witness_hash = 3;
 }
 
 // This is the definition of a transaction input

--- a/pkg/bitcoin/tx_test.go
+++ b/pkg/bitcoin/tx_test.go
@@ -1,7 +1,6 @@
 package bitcoin
 
 import (
-	"bytes"
 	"testing"
 )
 
@@ -39,15 +38,16 @@ func TestCreateTransaction(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-
-			var buf bytes.Buffer
-
-			err := s.CreateTransaction(&buf, tt.tx, tt.net)
+			tx, err := s.CreateTransaction(tt.tx, tt.net)
 			if err != nil && tt.wantErr == nil {
 				t.Fatalf("CreateTransaction() got error '%v'", err)
 			}
 
-			if buf.Len() == 0 {
+			if tx == nil {
+				t.Fatalf("CreateTransaction() got nil response")
+			}
+
+			if len(tx.Hex) == 0 {
 				t.Fatalf("Created Transaction is empty")
 			}
 		})


### PR DESCRIPTION
### What is this about?

This PR does some small cleanups in the `CreateTransaction` method. It also txid and witness hash in the protobuf response, which will be useful for tests.

### Cute picture of animal

![](https://media.tenor.com/images/90fd963f19c079251582075b82496475/tenor.gif)