### PR TITLE
Sign transaction

### DIFF
--- a/grpc/adapters.go
+++ b/grpc/adapters.go
@@ -1,9 +1,11 @@
 package grpc
 
 import (
+	"encoding/hex"
 	"strconv"
 
 	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcutil"
 	pb "github.com/ledgerhq/bitcoin-lib-grpc/pb/bitcoin"
 	"github.com/ledgerhq/bitcoin-lib-grpc/pkg/bitcoin"
 	"github.com/pkg/errors"
@@ -19,7 +21,7 @@ func BitcoinNetworkParams(network pb.BitcoinNetwork) (*chaincfg.Params, error) {
 		return &chaincfg.RegressionNetParams, nil
 	default:
 		return nil, errors.Wrapf(ErrUnknownNetwork,
-			"failed to decode network %s", network.String())
+			"failed to decode network params from network %s", network.String())
 	}
 }
 
@@ -33,7 +35,7 @@ func BitcoinChainParams(chainParams *pb.ChainParams) (bitcoin.ChainParams, error
 		return bitcoin.Regtest, nil
 	default:
 		return nil, errors.Wrapf(ErrUnknownNetwork,
-			"failed to decode network %s", network.String())
+			"failed to decode chain params from network %s", network.String())
 	}
 }
 
@@ -62,8 +64,6 @@ func Tx(txProto *pb.CreateTransactionRequest) (*bitcoin.Tx, error) {
 		inputs = append(inputs, bitcoin.Input{
 			OutputHash:  inputProto.OutputHash,
 			OutputIndex: uint32(inputProto.OutputIndex),
-			Script:      inputProto.Script,
-			Sequence:    inputProto.Sequence,
 		})
 	}
 
@@ -85,5 +85,56 @@ func Tx(txProto *pb.CreateTransactionRequest) (*bitcoin.Tx, error) {
 		Inputs:   inputs,
 		Outputs:  outputs,
 		LockTime: txProto.LockTime,
+	}, nil
+}
+
+// RawTx is an adapter function to build a *bitcoin.RawTx object from a gRPC message.
+func RawTx(rawTxProto *pb.RawTransactionResponse) *bitcoin.RawTx {
+	return &bitcoin.RawTx{
+		Hex:         rawTxProto.Hex,
+		Hash:        rawTxProto.Hash,
+		WitnessHash: rawTxProto.WitnessHash,
+	}
+}
+
+// Utxo is an adapter function to build a *bitcoin.Utxo object from a gRPC message.
+func Utxo(proto *pb.Utxo) (*bitcoin.Utxo, error) {
+	value, err := strconv.ParseInt(proto.Value, 10, 64)
+	if err != nil {
+		return nil, errors.Wrapf(err,
+			"invalid utxo value: %s", proto.Value)
+	}
+
+	return &bitcoin.Utxo{
+		Script:     proto.Script,
+		Value:      value,
+		Derivation: proto.Derivation,
+	}, nil
+}
+
+// SignatureMetadata is an adapter function to build a *bitcoin.SignatureMetadata object from a gRPC message.
+func SignatureMetadata(proto *pb.SignatureMetadata, chainParams bitcoin.ChainParams) (*bitcoin.SignatureMetadata, error) {
+	addrEncoding, err := BitcoinAddressEncoding(proto.AddrEncoding)
+	if err != nil {
+		return nil, errors.Wrapf(err,
+			"invalid output value: %s", proto.AddrEncoding)
+	}
+
+	serializedPubKey, err := hex.DecodeString(proto.PublicKey)
+	if err != nil {
+		return nil, errors.Wrapf(err,
+			"failed to parse serialized pub key from %s", proto.PublicKey)
+	}
+
+	addressPubKey, err := btcutil.NewAddressPubKey(serializedPubKey, chainParams)
+	if err != nil {
+		return nil, errors.Wrap(err,
+			"failed to parse pub key from signature")
+	}
+
+	return &bitcoin.SignatureMetadata{
+		DerSig:       proto.DerSignature,
+		PubKey:       addressPubKey.PubKey(),
+		AddrEncoding: addrEncoding,
 	}, nil
 }

--- a/pb/bitcoin/service.proto
+++ b/pb/bitcoin/service.proto
@@ -31,13 +31,20 @@ service CoinService {
   // HD version bytes during encoding.
   rpc EncodeAddress(EncodeAddressRequest) returns (EncodeAddressResponse) {}
 
-  // Create a Transaction
-  // the created transaction is returned to be signed
-  rpc CreateTransaction(CreateTransactionRequest) returns (CreateTransactionResponse) {}
+  // CreateTransaction prepares a transaction and returns a raw tx in order to be signed.
+  rpc CreateTransaction(CreateTransactionRequest) returns (RawTransactionResponse) {}
 
-    // GetKeypair accepts an optional seed and a bitcoin network 
+  // GetKeypair accepts an optional seed and a bitcoin network 
   // and returns a keypair of extended public key / private key.
   rpc GetKeypair(GetKeypairRequest) returns (GetKeypairResponse) {}
+
+  // GenerateDerSignatures 
+  rpc GenerateDerSignatures(GenerateDerSignaturesRequest) returns (GenerateDerSignaturesResponse) {}
+
+  // SignTransaction takes a raw tx and DER signatures,
+  // then compute scripts for all inputs.
+  // It returns the raw tx signed in order to be broadcasted.
+  rpc SignTransaction(SignTransactionRequest) returns (RawTransactionResponse) {}
 }
 
 // BitcoinNetwork enumerates the list of all supported Bitcoin networks. It
@@ -171,9 +178,8 @@ message CreateTransactionRequest {
   BitcoinNetwork network = 4;
 }
 
-// CreateTransactionResponse defines the output response passed to the
-// CreateTransaction RCP method.
-message CreateTransactionResponse {
+// RawTransactionResponse defines the builded raw tx.
+message RawTransactionResponse {
   // hex contains the unsigned transaction serialized according to bitcoin
   // encoding.
   string hex = 1;
@@ -195,10 +201,6 @@ message Input {
   string output_hash = 1;
   // Index of the utxo in the transaction
   int32 output_index = 2;
-  // Script used to verify utxo
-  string script = 3;
-  // sequence
-  uint32 sequence = 4;
 }
 
 // This is the definition of a transaction Output
@@ -223,4 +225,44 @@ message GetKeypairResponse {
   string extended_public_key = 1;
   // Private key
   string private_key = 2;
+}
+
+message Utxo {
+  // Output script
+  bytes script = 1;
+  // Output value
+  string value = 2;
+  // Derivation path
+  repeated uint32 derivation = 3;
+}
+
+message GenerateDerSignaturesRequest {
+  // Unsigned raw tx
+  RawTransactionResponse raw_tx = 1;
+  // Utxos
+  repeated Utxo utxos = 2;
+  // Master private key
+  string private_key = 3;
+}
+
+message GenerateDerSignaturesResponse {
+  repeated bytes der_signatures = 1;
+}
+
+message SignTransactionRequest {
+  // Unsigned raw tx
+  RawTransactionResponse raw_tx = 1;
+  // Network used (Main, Test, Reg...)
+  BitcoinNetwork network = 2;
+  // Signatures metadata
+  repeated SignatureMetadata signatures = 3;
+}
+
+message SignatureMetadata {
+  // Der signature
+  bytes der_signature = 1;
+  // Input pub key
+  string public_key = 2;
+  // Input Address encoding
+  AddressEncoding addr_encoding = 3;
 }

--- a/pkg/bitcoin/tx.go
+++ b/pkg/bitcoin/tx.go
@@ -4,17 +4,18 @@ import (
 	"bytes"
 	"encoding/hex"
 
+	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
+	"github.com/btcsuite/btcutil/hdkeychain"
+	"github.com/pkg/errors"
 )
 
 type Input struct {
 	OutputHash  string
 	OutputIndex uint32
-	Script      string
-	Sequence    uint32
 }
 
 type Output struct {
@@ -38,62 +39,251 @@ type RawTx struct {
 	WitnessHash string
 }
 
+type DerSignature = []byte
+
+type Utxo struct {
+	Script     []byte
+	Value      int64
+	Derivation []uint32
+}
+
+type SignatureMetadata struct {
+	DerSig       DerSignature
+	PubKey       *btcec.PublicKey
+	AddrEncoding AddressEncoding
+}
+
 func (s *Service) CreateTransaction(tx *Tx, chainParams ChainParams) (*RawTx, error) {
 	// Create a new btcd transaction
 	msgTx := wire.NewMsgTx(wire.TxVersion)
 
+	// For each input to spend, add a TxIn
 	for _, input := range tx.Inputs {
 		// hash string to hash byteArray
 		outputHash, err := chainhash.NewHashFromStr(input.OutputHash)
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrapf(err,
+				"failed to get hash string from output hash %s",
+				input.OutputHash,
+			)
 		}
 
-		// Outpoint = hash + index
+		// Previous outpoint = hash + index
 		prevOut := wire.NewOutPoint(outputHash, uint32(input.OutputIndex))
 
-		// Create new Input from outpoint and input script
-		txIn := wire.NewTxIn(prevOut, []byte(input.Script), nil)
+		// Create new Input from previous outpoint
+		txIn := wire.NewTxIn(prevOut, nil, nil)
 
-		// Add sequence
-		txIn.Sequence = input.Sequence
-
-		// Add input to btcd transaction
+		// Add TxIn to MsgTx
 		msgTx.AddTxIn(txIn)
 	}
 
+	// For each output to send, add a TxOut
 	for _, output := range tx.Outputs {
-		// Guess Address Type from address string
+		// Decode address from string
 		address, err := btcutil.DecodeAddress(output.Address, chainParams)
+
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrapf(err,
+				"failed to decode address from output address %s",
+				output.Address,
+			)
 		}
 
-		// Create a public key script that pays to the address depending on the address type.
-		script, err := txscript.PayToAddrScript(address)
+		// Create a 'pay to' script that pays to the address depending on the address type.
+		outputScript, err := txscript.PayToAddrScript(address)
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrapf(err,
+				"failed to build 'pay to' script from address %v",
+				address,
+			)
 		}
 
 		// Create Output from value and script
-		txOut := wire.NewTxOut(output.Value, script)
+		txOut := wire.NewTxOut(output.Value, outputScript)
 
-		// Add Output to btcd Transaction
+		// Add TxOut to MsgTx
 		msgTx.AddTxOut(txOut)
 	}
 
 	// Add LockTime
 	msgTx.LockTime = tx.LockTime
 
-	// Encode transaction in Hexadecimal
-	var buf bytes.Buffer
-	if err := msgTx.BtcEncode(&buf, wire.ProtocolVersion, wire.WitnessEncoding); err != nil {
+	// Encode MsgTx to RawTx
+	rawTx, err := encodeMsgTx(msgTx)
+	if err != nil {
 		return nil, err
 	}
 
-	return &RawTx{
+	return rawTx, nil
+}
+
+func (s *Service) GenerateDerSignatures(msgTx *wire.MsgTx, utxos []Utxo, privKey string) ([]DerSignature, error) {
+	// Validation
+	if len(msgTx.TxIn) != len(utxos) {
+		return nil, errors.New("inputs length != utxos length")
+	}
+
+	// Get extended key from private key
+	extendedKey, err := hdkeychain.NewKeyFromString(privKey)
+	if err != nil {
+		return nil, errors.Wrapf(err,
+			"failed to get extended key from private key %s",
+			privKey,
+		)
+	}
+
+	// Build sig hash type and sig hashes
+	sigHashType := txscript.SigHashAll
+	sigHashes := txscript.NewTxSigHashes(msgTx)
+
+	derSignatures := make([]DerSignature, len(msgTx.TxIn))
+
+	// Generate a valid der signature for each input
+	for idx, input := range msgTx.TxIn {
+		// Get the utxo assuming inputs and utxos are in the same order
+		utxo := utxos[idx]
+
+		script := utxo.Script
+
+		amount := utxo.Value
+
+		derivation := utxo.Derivation
+
+		// Derive the extended key for given derivation path
+		for _, childIndex := range derivation {
+			extendedKey, err = extendedKey.Derive(childIndex)
+			if err != nil {
+				return nil, errors.Wrapf(err, "failed to derive extendedKey %s at index %d",
+					extendedKey, childIndex)
+			}
+		}
+
+		// Get the private key for given derivation path
+		ecPrivKey, err := extendedKey.ECPrivKey()
+		if err != nil {
+			return nil, err
+		}
+
+		derSig, err := txscript.RawTxInWitnessSignature(msgTx, sigHashes, idx, amount, script, sigHashType, ecPrivKey)
+
+		if err != nil {
+			return nil, errors.Wrapf(err,
+				"failed to generate der signature for input %v",
+				input,
+			)
+		}
+
+		derSignatures[idx] = derSig
+	}
+
+	return derSignatures, nil
+}
+
+func (s *Service) SignTransaction(msgTx *wire.MsgTx, chainParams ChainParams, signatures []SignatureMetadata) (*RawTx, error) {
+	// Validation
+	if len(msgTx.TxIn) != len(signatures) {
+		return nil, errors.New("inputs length != signatures length")
+	}
+
+	for inputIdx, input := range msgTx.TxIn {
+
+		// Get the signature struct assuming inputs and signatures are in the same order
+		signature := signatures[inputIdx]
+
+		// Get the DER signature
+		derSig := signature.DerSig
+
+		// Get input address public key
+		pubKey := signature.PubKey
+
+		// Get address type for the input
+		inputAddrEncoding := signature.AddrEncoding
+
+		// Serialize input public key data
+		pubKeyData := pubKey.SerializeCompressed()
+
+		var sigScript []byte
+
+		// If we're spending p2wkh output nested within a p2sh output, then
+		// we'll need to attach a sigScript in addition to witness data.
+		// Otherwise sigScript is an empty byte array
+		if inputAddrEncoding == WrappedSegwit {
+			pubKeyHash := btcutil.Hash160(pubKeyData)
+
+			// Next, we'll generate a valid sigScript that will allow us to
+			// spend the p2sh output. The sigScript will contain only a
+			// single push of the p2wkh witness program corresponding to
+			// the matching public key of this address.
+			p2wkhAddr, err := btcutil.NewAddressWitnessPubKeyHash(
+				pubKeyHash, chainParams,
+			)
+
+			if err != nil {
+				return nil, err
+			}
+
+			redeemScript, err := txscript.PayToAddrScript(p2wkhAddr)
+			if err != nil {
+				return nil, err
+			}
+
+			bldr := txscript.NewScriptBuilder()
+			bldr.AddData(redeemScript)
+			sigScript, err = bldr.Script()
+
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		// Put signature script and witness data to the input
+		input.SignatureScript = sigScript
+		input.Witness = wire.TxWitness{derSig, pubKeyData}
+	}
+
+	// Encode signed MsgTx to RawTx
+	signedRawTx, err := encodeMsgTx(msgTx)
+	if err != nil {
+		return nil, err
+	}
+
+	return signedRawTx, nil
+}
+
+// Encode MsgTx to RawTx
+func encodeMsgTx(msgTx *wire.MsgTx) (*RawTx, error) {
+	var buf bytes.Buffer
+	if err := msgTx.Serialize(&buf); err != nil {
+		return nil, errors.Wrap(err, "failed to encode transaction in hex")
+	}
+
+	rawTx := &RawTx{
 		Hex:         hex.EncodeToString(buf.Bytes()),
 		Hash:        msgTx.TxHash().String(),
 		WitnessHash: msgTx.WitnessHash().String(),
-	}, nil
+	}
+
+	return rawTx, nil
+}
+
+// Deserialize MsgTx from RawTx
+func (s *Service) DeserializeMsgTx(rawTx *RawTx) (*wire.MsgTx, error) {
+	// Instantiate a MsgTx
+	msgTx := wire.NewMsgTx(wire.TxVersion)
+
+	// Get bytes from hex string
+	hexBytes, err := hex.DecodeString(rawTx.Hex)
+	if err != nil {
+		return nil, errors.Wrapf(err,
+			"failed to derialize raw tx %v",
+			rawTx,
+		)
+	}
+	reader := bytes.NewReader(hexBytes)
+
+	// Derialize into MsgTx
+	msgTx.Deserialize(reader)
+
+	return msgTx, nil
 }

--- a/pkg/bitcoin/tx.go
+++ b/pkg/bitcoin/tx.go
@@ -110,12 +110,7 @@ func (s *Service) CreateTransaction(tx *Tx, chainParams ChainParams) (*RawTx, er
 	msgTx.LockTime = tx.LockTime
 
 	// Encode MsgTx to RawTx
-	rawTx, err := encodeMsgTx(msgTx)
-	if err != nil {
-		return nil, err
-	}
-
-	return rawTx, nil
+	return encodeMsgTx(msgTx)
 }
 
 func (s *Service) GenerateDerSignatures(msgTx *wire.MsgTx, utxos []Utxo, privKey string) ([]DerSignature, error) {

--- a/pkg/bitcoin/tx_test.go
+++ b/pkg/bitcoin/tx_test.go
@@ -2,14 +2,18 @@ package bitcoin
 
 import (
 	"testing"
+
+	"github.com/btcsuite/btcd/btcec"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcutil"
 )
 
 func TestCreateTransaction(t *testing.T) {
 	tests := []struct {
-		name    string
-		tx      *Tx
-		net     ChainParams
-		wantErr error
+		name        string
+		tx          *Tx
+		chainParams ChainParams
+		wantErr     error
 	}{
 		{
 			name: "mainnet P2WPKH",
@@ -18,9 +22,7 @@ func TestCreateTransaction(t *testing.T) {
 				Inputs: []Input{
 					{
 						OutputHash:  "2f5dae23c2e18588c86cfc4e154f3b68bd8eb4265fe0b4b1341ad5aa40422f66",
-						OutputIndex: 1,
-						Script:      "160014513f387619014109e25764de4df3467b786ad125",
-						Sequence:    16777215,
+						OutputIndex: 0,
 					},
 				},
 				Outputs: []Output{
@@ -30,7 +32,7 @@ func TestCreateTransaction(t *testing.T) {
 					},
 				},
 			},
-			net: Mainnet,
+			chainParams: Mainnet,
 		},
 	}
 
@@ -38,17 +40,175 @@ func TestCreateTransaction(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tx, err := s.CreateTransaction(tt.tx, tt.net)
+			rawTx, err := s.CreateTransaction(tt.tx, tt.chainParams)
 			if err != nil && tt.wantErr == nil {
 				t.Fatalf("CreateTransaction() got error '%v'", err)
 			}
 
-			if tx == nil {
+			if rawTx == nil {
 				t.Fatalf("CreateTransaction() got nil response")
 			}
 
-			if len(tx.Hex) == 0 {
-				t.Fatalf("Created Transaction is empty")
+			if len(rawTx.Hex) == 0 {
+				t.Fatalf("CreateTransaction() got empty raw hex")
+			}
+		})
+	}
+}
+
+func TestGenerateDerSignatures(t *testing.T) {
+	tests := []struct {
+		name    string
+		msgTx   *wire.MsgTx
+		utxos   []Utxo
+		privKey string
+		wantErr error
+	}{
+		{
+			name: "generate DER signatures",
+			msgTx: &wire.MsgTx{
+				Version: 1,
+				TxIn: []*wire.TxIn{
+					wire.NewTxIn(
+						wire.NewOutPoint(btcutil.NewTx(wire.NewMsgTx(1)).Hash(), 0),
+						nil,
+						nil,
+					),
+				},
+				LockTime: 0x0,
+			},
+			utxos: []Utxo{
+				{
+					Script:     nil,
+					Value:      100000,
+					Derivation: []uint32{44 + h, 0 + h, 0 + h, 0, 0},
+				},
+			},
+			privKey: "xprv9yv8fLFeRhD7NcKbjGS4GesBvy2PjvoRcwEKKaz7zJvM2cQ1eiCwhcHGQNEBwsXthHbPtZNQg5SBBEWS1QH941SKitBdaUT7VDTxzdS8vu7",
+		},
+	}
+
+	s := &Service{}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			derSignatures, err := s.GenerateDerSignatures(tt.msgTx, tt.utxos, tt.privKey)
+			if err != nil && tt.wantErr == nil {
+				t.Fatalf("GenerateDerSignatures() got error '%v'", err)
+			}
+
+			if tt.wantErr == nil {
+				if derSignatures == nil {
+					t.Fatal("GenerateDerSignatures() got nil response")
+				}
+
+				countDerSignatures := len(derSignatures)
+				countUtxos := len(tt.utxos)
+
+				if countDerSignatures != countUtxos {
+					t.Fatalf(
+						"GenerateDerSignatures has generated %d signatures instead of %d",
+						countDerSignatures,
+						countUtxos,
+					)
+				}
+			}
+		})
+	}
+}
+
+func TestSignTransaction(t *testing.T) {
+	// Helper to derive extended key and return the btcec public key.
+	// Use this in unit-tests to get input public key.
+	getPublicKey := func(extendedKey string, derivation []uint32, chainParams ChainParams) *btcec.PublicKey {
+		s := &Service{}
+
+		pubKeyMat, err := s.DeriveExtendedKey(extendedKey, derivation)
+		if err != nil {
+			panic(err)
+		}
+
+		addressPubKey, err := btcutil.NewAddressPubKey(pubKeyMat.PublicKey, chainParams)
+		if err != nil {
+			panic(err)
+		}
+
+		return addressPubKey.PubKey()
+	}
+
+	tests := []struct {
+		name               string
+		msgTx              *wire.MsgTx
+		chainParams        ChainParams
+		utxos              []Utxo
+		privKey            string
+		signaturesMetadata []SignatureMetadata
+		wantErr            error
+	}{
+		{
+			name: "sign transaction",
+			msgTx: &wire.MsgTx{
+				Version: 1,
+				TxIn: []*wire.TxIn{
+					wire.NewTxIn(
+						wire.NewOutPoint(btcutil.NewTx(wire.NewMsgTx(1)).Hash(), 0),
+						nil,
+						nil,
+					),
+				},
+				LockTime: 0x0,
+			},
+			chainParams: Mainnet,
+			utxos: []Utxo{
+				{
+					Script:     nil,
+					Value:      100000,
+					Derivation: []uint32{44 + h, 0 + h, 0 + h, 0, 0},
+				},
+			},
+			privKey: "xprv9yv8fLFeRhD7NcKbjGS4GesBvy2PjvoRcwEKKaz7zJvM2cQ1eiCwhcHGQNEBwsXthHbPtZNQg5SBBEWS1QH941SKitBdaUT7VDTxzdS8vu7",
+			signaturesMetadata: []SignatureMetadata{
+				{
+					DerSig: nil,
+					PubKey: getPublicKey(
+						"xpub6Cc939fyHvfB9pPLWd3bSyyQFvgKbwhidca49jGCM5Hz5ypEPGf9JVXB4NBuUfPgoHnMjN6oNgdC9KRqM11RZtL8QLW6rFKziNwHDYhZ6Kx",
+						[]uint32{1, 1},
+						Mainnet,
+					),
+					AddrEncoding: Legacy,
+				},
+			},
+		},
+	}
+
+	s := &Service{}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			derSignatures, err := s.GenerateDerSignatures(tt.msgTx, tt.utxos, tt.privKey)
+			if err != nil && tt.wantErr == nil {
+				t.Fatalf("GenerateDerSignatures() got error '%v'", err)
+			}
+
+			// Put DER signatures
+			for idx := range tt.signaturesMetadata {
+				tt.signaturesMetadata[idx].DerSig = derSignatures[idx]
+			}
+
+			signedRawTx, err := s.SignTransaction(tt.msgTx, tt.chainParams, tt.signaturesMetadata)
+			if err != nil && tt.wantErr == nil {
+				t.Fatalf("SignTransaction() got error '%v'", err)
+			}
+
+			if tt.wantErr == nil {
+				if signedRawTx == nil {
+					t.Fatal("SignTransaction() got nil response")
+				}
+
+				if len(signedRawTx.Hex) == 0 {
+					t.Fatal("SignTransaction() got empty raw hex")
+				}
 			}
 		})
 	}


### PR DESCRIPTION
Sign transaction (all kind of `pay to` tx)
- Deserialize prepared raw tx into a btcd msg tx (`wire.MsgTx`)
- For each input, compute sigScript and witness data with the corresponding DER signature
- Encode the btcd msg tx to return the signed raw tx

For testing, there's also a convenient service to generate DER signatures