### PR TITLE
Add test cases for validity of UPPERCASE BECH32 addresses

### DIFF
--- a/pkg/core/address_test.go
+++ b/pkg/core/address_test.go
@@ -35,6 +35,18 @@ func TestService_ValidateAddress(t *testing.T) {
 			wantErr:     errors.New("string not all lowercase or all uppercase"),
 		},
 		{
+			name:        "mainnet bech32 UPPERCASE valid",
+			address:     "BC1QH4KL0A0A3D7SU8UDC2RN62F8W939PRQPL34Z86",
+			chainParams: chaincfg.BitcoinMainNetParams,
+			want:        "bc1qh4kl0a0a3d7su8udc2rn62f8w939prqpl34z86",
+		},
+		{
+			name:        "mainnet P2PKH UPPERCASE invalid",
+			address:     "1MIRQ9BWYQCGVJPWKUGAPU5OUK2E2EY4GX",
+			chainParams: chaincfg.BitcoinMainNetParams,
+			wantErr:     errors.New("decoded address is of unknown format"),
+		},
+		{
 			name:        "LTC mainnet P2WPKH valid",
 			address:     "ltc1q7qnj9xm8wp8ucmg64lk0h03as8k6ql6rk4wvsd",
 			chainParams: chaincfg.LitecoinMainNetParams,


### PR DESCRIPTION
### What is this about?

ALL-UPPERCASE bech32 addresses should be considered valid. MiXeD-casing is not allowed. The PR adds some test cases to cover this.

**Note:** The validated address that's returned will be lowercased, however, the client is free to ignore this.

**References:**
* https://github.com/btcpayserver/btcpayserver/issues/2110
* https://twitter.com/P3b7_/status/1371374977115639809

### Cute picture of animal

![](https://media1.tenor.com/images/45bab3e535d9c61620d782e280664cb2/tenor.gif?itemid=10423165)