### PR TITLE
BACK-1673: add more information in CreateTxResponse

### DIFF
--- a/grpc/bitcoin.go
+++ b/grpc/bitcoin.go
@@ -113,21 +113,23 @@ func (c *controller) CreateTransaction(
 		return nil, status.Errorf(codes.InvalidArgument, err.Error())
 	}
 
-	rawTx, err := c.svc.CreateTransaction(tx, chainParams)
+	rawTxWithExtra, err := c.svc.CreateTransaction(tx, chainParams)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, err.Error())
 	}
 
-	var notEnoughtUtxo *pb.NotEnoughUtxo
-	if rawTx.NotEnoughUtxo != nil {
-		notEnoughtUtxo = &pb.NotEnoughUtxo{MissingAmount: rawTx.NotEnoughUtxo.MissingAmount}
+	var notEnoughUtxo *pb.NotEnoughUtxo
+	if rawTxWithExtra.RawTx.NotEnoughUtxo != nil {
+		notEnoughUtxo = &pb.NotEnoughUtxo{MissingAmount: rawTxWithExtra.RawTx.NotEnoughUtxo.MissingAmount}
 	}
 
 	response := pb.RawTransactionResponse{
-		Hex:           rawTx.Hex,
-		Hash:          rawTx.Hash,
-		WitnessHash:   rawTx.WitnessHash,
-		NotEnoughUtxo: notEnoughtUtxo,
+		Hex:           rawTxWithExtra.RawTx.Hex,
+		Hash:          rawTxWithExtra.RawTx.Hash,
+		WitnessHash:   rawTxWithExtra.RawTx.WitnessHash,
+		ChangeAmount:  rawTxWithExtra.Change,
+		TotalFees:     rawTxWithExtra.TotalFees,
+		NotEnoughUtxo: notEnoughUtxo,
 	}
 
 	return &response, nil

--- a/pb/bitcoin/service.proto
+++ b/pb/bitcoin/service.proto
@@ -221,7 +221,7 @@ message CreateTransactionRequest {
   int64 fee_sat_per_kb = 6;
 }
 
-// RawTransactionResponse defines the builded raw tx.
+// RawTransactionResponse defines the built raw tx.
 message RawTransactionResponse {
   // hex contains the unsigned transaction serialized according to bitcoin
   // encoding.
@@ -237,8 +237,12 @@ message RawTransactionResponse {
   // Same as hash if no witness is present.
   string witness_hash = 3;
 
+  int64 change_amount = 4;
+
+  int64 total_fees = 5;
+
   // If not enough utxos to pay for fees.
-  NotEnoughUtxo not_enough_utxo = 4;
+  NotEnoughUtxo not_enough_utxo = 6;
 }
 
 message NotEnoughUtxo {

--- a/pkg/core/tx.go
+++ b/pkg/core/tx.go
@@ -49,8 +49,8 @@ type RawTx struct {
 }
 
 type RawTxWithChangeFees struct {
-	RawTx RawTx
-	Change int64
+	RawTx     RawTx
+	Change    int64
 	TotalFees int64
 }
 

--- a/pkg/core/tx_test.go
+++ b/pkg/core/tx_test.go
@@ -77,16 +77,16 @@ func TestCreateTransaction(t *testing.T) {
 				t.Fatalf("CreateTransaction() got error '%v'", err)
 			}
 
-			if rawTx.NotEnoughUtxo != nil && tt.wantNotEnoughUtxoAmount == nil {
-				t.Fatalf("CreateTransaction() got NotEnoughUtxo '%v'", rawTx.NotEnoughUtxo)
+			if rawTx.RawTx.NotEnoughUtxo != nil && tt.wantNotEnoughUtxoAmount == nil {
+				t.Fatalf("CreateTransaction() got NotEnoughUtxo '%v'", rawTx.RawTx.NotEnoughUtxo)
 			}
 
-			if rawTx.NotEnoughUtxo == nil && tt.wantNotEnoughUtxoAmount != nil {
+			if rawTx.RawTx.NotEnoughUtxo == nil && tt.wantNotEnoughUtxoAmount != nil {
 				t.Fatalf("CreateTransaction() should have '%v'", tt.wantNotEnoughUtxoAmount)
 			}
 
-			if rawTx.NotEnoughUtxo != nil && tt.wantNotEnoughUtxoAmount != nil && rawTx.NotEnoughUtxo.MissingAmount != tt.wantNotEnoughUtxoAmount.MissingAmount {
-				t.Fatalf("CreateTransaction() got NotEnoughUtxo '%v'", rawTx.NotEnoughUtxo)
+			if rawTx.RawTx.NotEnoughUtxo != nil && tt.wantNotEnoughUtxoAmount != nil && rawTx.RawTx.NotEnoughUtxo.MissingAmount != tt.wantNotEnoughUtxoAmount.MissingAmount {
+				t.Fatalf("CreateTransaction() got NotEnoughUtxo '%v'", rawTx.RawTx.NotEnoughUtxo)
 			}
 
 			if tt.wantNotEnoughUtxoAmount == nil {
@@ -94,7 +94,7 @@ func TestCreateTransaction(t *testing.T) {
 					t.Fatalf("CreateTransaction() got nil response")
 				}
 
-				if len(rawTx.Hex) == 0 {
+				if len(rawTx.RawTx.Hex) == 0 {
 					t.Fatalf("CreateTransaction() got empty raw hex")
 				}
 			}


### PR DESCRIPTION
As the CreateTransaction service has 2 purposes (setting the change output and serializing), we expose the "setting change output" effect in a parse-able way. We don't want to parse the RawTx again to know the change amount and the total fees for the created transaction

Changes:

- change_amount is added to CreateTransactionResponse
- total_fees is added to CreateTransactionResponse